### PR TITLE
add back std::variant for the time being

### DIFF
--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -342,7 +342,7 @@ namespace eosio { namespace vm {
             if (_pc == _exit_pc && _as.size() <= 1) {
                _executing = false;
             }
-            visit(visitor, _mod.code.at_no_check(_code_index).code.at_no_check(offset));
+            std::visit(visitor, _mod.code.at_no_check(_code_index).code.at_no_check(offset));
          } while (_executing);
       }
 

--- a/include/eosio/vm/opcodes.hpp
+++ b/include/eosio/vm/opcodes.hpp
@@ -73,7 +73,7 @@ namespace eosio { namespace vm {
    EMPTY_OPS(CREATE_TYPES)
    ERROR_OPS(CREATE_TYPES)
 
-   using opcode = eosio::vm::variant<
+   using opcode = std::variant<
       CONTROL_FLOW_OPS(IDENTITY)
       BR_TABLE_OP(IDENTITY)
       RETURN_OP(IDENTITY)

--- a/include/eosio/vm/parser.hpp
+++ b/include/eosio/vm/parser.hpp
@@ -237,7 +237,7 @@ namespace eosio { namespace vm {
                case opcodes::end: {
                   if (pc_stack.size()) {
                      auto& el = fb[pc_stack.top()];
-                     eosio::vm::visit(overloaded{ [=](block_t& bt) { bt.pc = op_index; },
+                     std::visit(overloaded{ [=](block_t& bt) { bt.pc = op_index; },
                                             [=](loop_t& lt) { lt.pc = pc_stack.top(); },
                                             [=](if__t& it) { it.pc = op_index; },
                                             [=](else__t& et) { et.pc = op_index; },
@@ -271,7 +271,7 @@ namespace eosio { namespace vm {
                   auto old_index = pc_stack.top();
                   pc_stack.pop();
                   pc_stack.push(op_index);
-                  auto& _if      = fb[old_index].get<if__t>();
+                  auto& _if      = std::get<if__t>(fb[old_index]);
                   _if.pc         = op_index;
                   fb[op_index++] = else__t{};
                   break;


### PR DESCRIPTION
Add back the use of std::variant for now, very close to having the new fast variant system in, but for the public release rather go with a more stable system.