### PR TITLE
Redo the implementation of watchdog.

### DIFF
--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -69,10 +69,9 @@ namespace eosio { namespace vm {
          }
       }
 
-      template <typename Watchdog = nullptr_t>
-      inline void execute_all(Watchdog* wd = nullptr, Host* host = nullptr) {
-         if constexpr (!std::is_same_v<Watchdog, nullptr_t>)
-            wd->run();
+      template <typename Watchdog>
+      inline void execute_all(Watchdog&& wd, Host* host = nullptr) {
+         auto wd_guard = wd();
          for (int i = 0; i < _mod.exports.size(); i++) {
             if (_mod.exports[i].kind == external_kind::Function) {
                std::string s{ (const char*)_mod.exports[i].field_str.raw(), _mod.exports[i].field_str.size() };

--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -71,7 +71,7 @@ namespace eosio { namespace vm {
 
       template <typename Watchdog>
       inline void execute_all(Watchdog&& wd, Host* host = nullptr) {
-         auto wd_guard = wd();
+         auto wd_guard = wd.scoped_run([this]() { _ctx.exit(); });
          for (int i = 0; i < _mod.exports.size(); i++) {
             if (_mod.exports[i].kind == external_kind::Function) {
                std::string s{ (const char*)_mod.exports[i].field_str.raw(), _mod.exports[i].field_str.size() };

--- a/include/eosio/vm/watchdog.hpp
+++ b/include/eosio/vm/watchdog.hpp
@@ -77,6 +77,6 @@ namespace eosio { namespace vm {
       std::function<void()> _callback;
    };
 
-   auto null_watchdog() { return [](){ return 0; }; }
+   inline auto null_watchdog() { return [](){ return 0; }; }
 
 }} // namespace eosio::vm

--- a/include/eosio/vm/watchdog.hpp
+++ b/include/eosio/vm/watchdog.hpp
@@ -2,55 +2,81 @@
 
 #include <eosio/vm/error_codes_def.hpp>
 
-#include <atomic>
 #include <chrono>
 #include <functional>
 #include <thread>
+#include <mutex>
+#include <condition_variable>
 
 namespace eosio { namespace vm {
-   //TODO use Spoons accurate timer
-   template <typename TimeUnits>
+
+   /// \brief Triggers a callback after a given time elapses.
+   ///
    class watchdog {
+      class guard;
     public:
-      watchdog() = default;
-      template <typename F>
-      watchdog(const TimeUnits& duration, F&& cb) : _duration(duration), _callback(cb) {}
-      ~watchdog() {
-         _should_exit = true;
-         _timer.detach();
-      }
-      void      set_duration(const TimeUnits& duration) { _duration = duration; }
-      TimeUnits get_duration() const { return _duration; }
-      void      join() { _timer.join(); }
-      void      detach() { _timer.detach(); }
-      template <typename F>
-      void set_callback(F&& callback) {
-         _callback = callback;
-      }
-      void run() {
-         _start      = std::chrono::high_resolution_clock::now();
-         _is_running = true;
-      }
+      template <typename TimeUnits, typename F>
+      watchdog(const TimeUnits& duration, F&& callback) : _duration(duration), _callback(callback) {}
+      /// Starts the timer.  If the timer
+      /// expires during the lifetime of the returned object, the callback
+      /// will be executed.  The callback is executed asynchronously.
+      /// If invoking the callback throws an exception, terminate will
+      /// be called.
+      guard operator()() { return guard(_duration, _callback); }
 
     private:
-      void runner() {
-         while (!_should_exit) {
-            if (_is_running) {
-               auto _now = std::chrono::high_resolution_clock::now();
-               if (std::chrono::duration_cast<TimeUnits>(_now - _start) >= _duration) {
-                  _is_running = false;
-                  if (_callback)
-                     _callback();
-               }
+      class guard {
+       public:
+         guard(const guard&) = delete;
+         guard& operator=(const guard&) = delete;
+
+         template <typename TimeUnits, typename F>
+         guard(const TimeUnits& duration, F&& callback)
+            : _callback(static_cast<F&&>(callback)),
+              _run_state(running),
+              _duration(duration),
+              _start(std::chrono::steady_clock::now()) {
+            // Must be started after all other initialization to avoid races.
+            _timer = std::thread(&guard::runner, this);
+         }
+         ~guard() {
+            {
+               auto _lock = std::unique_lock(_mutex);
+               _run_state = stopped;
+            }
+            _cond.notify_one();
+            _timer.join();
+         }
+
+       private:
+         // worker thread
+         // Implementation notes: This implementation creates a thread for
+         // each watchdog.  If there are many watchdogs, it might be more
+         // efficient to create a single thread for them all.
+         void runner() {
+            auto _lock = std::unique_lock(_mutex);
+            // wait until the timer expires or someone stops it.
+            _cond.wait_until(_lock, _start + _duration, [&]() { return _run_state != running; });
+            if (_run_state == running) {
+               _run_state = interrupted;
+               _callback();
             }
          }
-      }
-      using time_point_type              = std::chrono::time_point<std::chrono::high_resolution_clock>;
-      std::thread           _timer       = std::thread(&watchdog::runner, this);
-      std::atomic<bool>     _should_exit = false;
+         enum state_t { running, interrupted, stopped };
+         using time_point_type              = std::chrono::time_point<std::chrono::steady_clock>;
+         using duration_type = std::chrono::steady_clock::duration;
+         std::thread           _timer;
+         std::mutex            _mutex;
+         std::condition_variable _cond;
+         std::function<void()> _callback;
+         bool                  _run_state = stopped;
+         duration_type         _duration;
+         time_point_type       _start;
+      };
+      std::chrono::steady_clock::duration _duration;
       std::function<void()> _callback;
-      bool                  _is_running = false;
-      TimeUnits             _duration;
-      time_point_type       _start;
    };
+
+   auto null_watchdog() { return [](){ return 0; }; }
+
 }} // namespace eosio::vm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,6 @@ catch_discover_tests( eos_vm_spec_tests )
 
 add_executable( watchdog_tests watchdog_tests.cpp )
 target_include_directories( watchdog_tests PUBLIC ${CMAKE_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
-target_link_libraries( watchdog_tests ${Boost_LIBRARIES} )
+target_link_libraries( watchdog_tests Boost::unit_test_framework )
 
 add_test(NAME watchdog_tests COMMAND watchdog_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,9 @@
 option(ENABLE_TESTS "enable building of unit tests, spec tests." ON)
 cmake_dependent_option(ENABLE_FUZZ_TESTS "enable fuzz testing" OFF "ENABLE_TESTS" ON)
 
+set(Boost_USE_STATIC_LIBS TRUE)
+find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+
 configure_file(wasm_config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/wasm_config.hpp)
 include_directories(${CMAKE_SOURCE_DIR}/external/Catch2/single_include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -36,3 +39,9 @@ target_include_directories( eos_vm_spec_tests PUBLIC ${CMAKE_BINARY_DIR}/tests/s
 add_executable( spec_test_generator ${CMAKE_CURRENT_SOURCE_DIR}/spec_tests/spec_test_generator/spec_test_generator.cpp )
 
 catch_discover_tests( eos_vm_spec_tests )
+
+add_executable( watchdog_tests watchdog_tests.cpp )
+target_include_directories( watchdog_tests PUBLIC ${CMAKE_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
+target_link_libraries( watchdog_tests ${Boost_LIBRARIES} )
+
+add_test(NAME watchdog_tests COMMAND watchdog_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,6 @@ catch_discover_tests( eos_vm_spec_tests )
 
 add_executable( watchdog_tests watchdog_tests.cpp )
 target_include_directories( watchdog_tests PUBLIC ${CMAKE_SOURCE_DIR}/include ${Boost_INCLUDE_DIR})
-target_link_libraries( watchdog_tests Boost::unit_test_framework )
+target_link_libraries( watchdog_tests )
 
 add_test(NAME watchdog_tests COMMAND watchdog_tests)

--- a/tests/fuzz/fuzz_driver.cpp
+++ b/tests/fuzz/fuzz_driver.cpp
@@ -1,4 +1,5 @@
 #include <eosio/wasm_backend/backend.hpp>
+#include <eosio/vm/watchdog.hpp>
 
 using namespace eosio;
 using namespace eosio::wasm_backend;
@@ -9,5 +10,5 @@ extern "C" int LLVMFuzzerTestOneInput( const uint8_t* data, size_t size ) {
    wc.resize(size);
    memcpy((uint8_t*)wc.data(), data, size);
    backend<std::nullptr_t> bkend( wc );
-   bkend.execute_all(nullptr);
+   bkend.execute_all(null_watchdog());
 }

--- a/tests/watchdog_tests.cpp
+++ b/tests/watchdog_tests.cpp
@@ -10,9 +10,9 @@ BOOST_AUTO_TEST_SUITE(watchdog_tests)
 
 BOOST_AUTO_TEST_CASE(watchdog_interrupt) {
   std::atomic<bool> okay = false;
+  watchdog w{std::chrono::milliseconds(50)};
   {
-    watchdog w(std::chrono::milliseconds(50), [&]() { okay = true; });
-    auto g = w();
+    auto g = w.scoped_run([&]() { okay = true; });
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   BOOST_TEST(okay);
@@ -20,10 +20,10 @@ BOOST_AUTO_TEST_CASE(watchdog_interrupt) {
 
 BOOST_AUTO_TEST_CASE(watchdog_no_interrupt) {
   std::atomic<bool> okay = true;
+  watchdog w{std::chrono::milliseconds(50)};
   {
-    watchdog w(std::chrono::milliseconds(50), [&]() { okay = false; });
-    auto g = w();
-  }
+    auto g = w.scoped_run([&]() { okay = false; });
+  } // the guard goes out of scope here, cancelling the timer
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   BOOST_TEST(okay);
 }

--- a/tests/watchdog_tests.cpp
+++ b/tests/watchdog_tests.cpp
@@ -1,0 +1,31 @@
+#include <eosio/vm/watchdog.hpp>
+#include <chrono>
+
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using eosio::vm::watchdog;
+
+BOOST_AUTO_TEST_SUITE(watchdog_tests)
+
+BOOST_AUTO_TEST_CASE(watchdog_interrupt) {
+  std::atomic<bool> okay = false;
+  {
+    watchdog w(std::chrono::milliseconds(50), [&]() { okay = true; });
+    auto g = w();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  BOOST_TEST(okay);
+}
+
+BOOST_AUTO_TEST_CASE(watchdog_no_interrupt) {
+  std::atomic<bool> okay = true;
+  {
+    watchdog w(std::chrono::milliseconds(50), [&]() { okay = false; });
+    auto g = w();
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  BOOST_TEST(okay);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/watchdog_tests.cpp
+++ b/tests/watchdog_tests.cpp
@@ -2,7 +2,7 @@
 #include <chrono>
 
 #define BOOST_TEST_MAIN
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 using eosio::vm::watchdog;
 

--- a/tools/bench_interp.cpp
+++ b/tools/bench_interp.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv) {
       bkend.set_wasm_allocator( &wa );
 
       auto t3 = std::chrono::high_resolution_clock::now();
-      bkend.execute_all();
+      bkend.execute_all(null_watchdog());
       auto t4 = std::chrono::high_resolution_clock::now();
       std::cout << "Execution " << std::chrono::duration_cast<std::chrono::nanoseconds>(t4-t3).count() << "\n";
 

--- a/tools/hello_driver.cpp
+++ b/tools/hello_driver.cpp
@@ -51,10 +51,10 @@ int main(int argc, char** argv) {
    // finally register memset
    rhf_t::add<nullptr_t, &example_host_methods::memset, wasm_allocator>("env", "memset");
 
+   watchdog wd{std::chrono::seconds(3)};
    try {
       // Instaniate a new backend using the wasm provided.
       backend_t bkend(hello_wasm);
-      watchdog wd(std::chrono::seconds(3), [&]() { bkend.get_context().exit(); });
 
       // Point the backend to the allocator you want it to use.
       bkend.set_wasm_allocator(&wa);

--- a/tools/hello_driver.cpp
+++ b/tools/hello_driver.cpp
@@ -51,12 +51,10 @@ int main(int argc, char** argv) {
    // finally register memset
    rhf_t::add<nullptr_t, &example_host_methods::memset, wasm_allocator>("env", "memset");
 
-   watchdog<std::chrono::nanoseconds> wd;
-   wd.set_duration(std::chrono::seconds(3));
    try {
       // Instaniate a new backend using the wasm provided.
       backend_t bkend(hello_wasm);
-      wd.set_callback([&]() { bkend.get_context().exit(); });
+      watchdog wd(std::chrono::seconds(3), [&]() { bkend.get_context().exit(); });
 
       // Point the backend to the allocator you want it to use.
       bkend.set_wasm_allocator(&wa);

--- a/tools/interp.cpp
+++ b/tools/interp.cpp
@@ -21,15 +21,14 @@ int main(int argc, char** argv) {
       return -1;
    }
 
+   watchdog wd{std::chrono::seconds(3)};
+
    try {
       // Read the wasm into memory.
       auto code = backend_t::read_wasm( argv[1] );
 
       // Instaniate a new backend using the wasm provided.
       backend_t bkend( code );
-      watchdog wd(std::chrono::seconds(3), [&](){
-		      bkend.get_context().exit();
-		      });
 
       // Point the backend to the allocator you want it to use.
       bkend.set_wasm_allocator( &wa );

--- a/tools/interp.cpp
+++ b/tools/interp.cpp
@@ -21,15 +21,13 @@ int main(int argc, char** argv) {
       return -1;
    }
 
-   watchdog<std::chrono::nanoseconds> wd;
-   wd.set_duration(std::chrono::seconds(3));
    try {
       // Read the wasm into memory.
       auto code = backend_t::read_wasm( argv[1] );
 
       // Instaniate a new backend using the wasm provided.
       backend_t bkend( code );
-      wd.set_callback([&](){
+      watchdog wd(std::chrono::seconds(3), [&](){
 		      bkend.get_context().exit();
 		      });
 
@@ -37,7 +35,7 @@ int main(int argc, char** argv) {
       bkend.set_wasm_allocator( &wa );
 
       // Execute any exported functions provided by the wasm.
-      bkend.execute_all(&wd);
+      bkend.execute_all(wd);
 
    } catch ( ... ) {
       std::cerr << "eos-vm interpreter error\n";


### PR DESCRIPTION
* Fixed data races.
* Running the watchdog has been moved into a nested RAII wrapper.
* null_watchdog() replaces nullptr when no watchdog is needed.
* sleep instead of spinning in the worker thread.
* Added tests for watchdog.