### PR TITLE
Resolve control flow at parse time

### DIFF
--- a/include/eosio/vm/interpret_visitor.hpp
+++ b/include/eosio/vm/interpret_visitor.hpp
@@ -95,21 +95,19 @@ namespace eosio { namespace vm {
          context.push_label(op);
       }
       [[gnu::always_inline]] inline void operator()(const else__t& op) { context.set_relative_pc(op.pc); }
-      [[gnu::always_inline]] inline void operator()(const br_t& op) { context.jump(op.data); }
+      [[gnu::always_inline]] inline void operator()(const br_t& op) { context.jump(op.data, op.pc); }
       [[gnu::always_inline]] inline void operator()(const br_if_t& op) {
          const auto& val = context.pop_operand();
          if (context.is_true(val)) {
-            context.jump(op.data);
+            context.jump(op.data, op.pc);
          } else {
             context.inc_pc();
          }
       }
       [[gnu::always_inline]] inline void operator()(const br_table_t& op) {
          const auto& in = to_ui32(context.pop_operand());
-         if (in < op.size)
-            context.jump(op.table[in]);
-         else
-            context.jump(op.default_target);
+         const auto& entry = op.table[std::min(in, op.size)]; 
+         context.jump(op.table[in].stack_pop, entry.pc);
       }
       [[gnu::always_inline]] inline void operator()(const call_t& op) {
          context.call(op.index);

--- a/include/eosio/vm/opcodes_def.hpp
+++ b/include/eosio/vm/opcodes_def.hpp
@@ -283,9 +283,9 @@
 #define CREATE_BR_TABLE_TYPE(name, code)                                                                               \
    struct name##_t {                                                                                                   \
       name##_t() = default;                                                                                            \
-      uint32_t* table;                                                                                                 \
+      struct elem_t { uint32_t pc; uint32_t stack_pop; };                                                              \
+      elem_t* table;                                                                                                   \
       uint32_t  size;                                                                                                  \
-      uint32_t  default_target;                                                                                        \
    };
 
 #define CREATE_TYPES(name, code)                                                                                       \


### PR DESCRIPTION
This gives a small but fairly consistent speedup across the benchmarks.
It also resolves a bug when branching to a function label (which should be equivalent to return).
