### PR TITLE
Fixes for base image scripts

### DIFF
--- a/.cicd/docker-hash.sh
+++ b/.cicd/docker-hash.sh
@@ -1,4 +1,4 @@
-export IMAGE_TAG=${IMAGE_TAG:-'ubuntu-18.04'}
+export IMAGE_TAG=${IMAGE_TAG:-$1}
 
 function determine-hash()
 {

--- a/.cicd/generate-base-images.sh
+++ b/.cicd/generate-base-images.sh
@@ -6,11 +6,12 @@ echo "+++ :mag_right: Looking for $FULL_TAG"
 ORG_REPO=$(echo $FULL_TAG | cut -d: -f1)
 TAG=$(echo $FULL_TAG | cut -d: -f2)
 EXISTS=$(curl -s -H "Authorization: Bearer $(curl -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${ORG_REPO}:pull" | jq --raw-output .token)" "https://registry.hub.docker.com/v2/${ORG_REPO}/manifests/$TAG")
-if [[ $EXISTS =~ '404 page not found' || $EXISTS =~ 'manifest unknown' ]]; then
-    echo "$FULL_TAG already exists."
-else # if we cannot pull the image, we build and push it first
+
+if [[ $EXISTS =~ '404 page not found' || $EXISTS =~ 'manifest unknown' ]]; then # if we cannot pull the image, we build and push it first
     docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
     cd ./.cicd
     docker build -t $FULL_TAG -f ./${IMAGE_TAG}.dockerfile .
     docker push $FULL_TAG
+else
+    echo "$FULL_TAG already exists."
 fi


### PR DESCRIPTION
- `docker-hash.sh` now defaults to first parameter instead of ubuntu-18.04 for the IMAGE_TAG variable. This allows the `base-images` pipeline to function properly.
- Fixed reversed logic in `generate-base-images.sh` when detecting whether a tag already exists for Dockerfiles.