### PR TITLE
Replace buildkite docker plugin

### DIFF
--- a/.cicd/amazonlinux-2.dockerfile
+++ b/.cicd/amazonlinux-2.dockerfile
@@ -28,7 +28,5 @@ RUN git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.
 # ccache
 RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
     yum install -y ccache-3.3.4-1.el7.x86_64.rpm
-# Testing purposes.
-RUN echo "This is a test for eos-vm branch trav-poc-docker-script."
 # container entrypoint
 CMD /workdir/.cicd/entrypoint.sh

--- a/.cicd/amazonlinux-2.dockerfile
+++ b/.cicd/amazonlinux-2.dockerfile
@@ -28,5 +28,7 @@ RUN git clone --single-branch --branch release_80 https://git.llvm.org/git/llvm.
 # ccache
 RUN curl -LO http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/c/ccache-3.3.4-1.el7.x86_64.rpm && \
     yum install -y ccache-3.3.4-1.el7.x86_64.rpm
+# Testing purposes.
+RUN echo "This is a test for eos-vm branch trav-poc-docker-script."
 # container entrypoint
 CMD /workdir/.cicd/entrypoint.sh

--- a/.cicd/cicd-build.sh
+++ b/.cicd/cicd-build.sh
@@ -4,7 +4,6 @@ set -eo pipefail
 . ./.cicd/docker-hash.sh
 
 if [[ $TRAVIS ]]; then
-  echo "This build is running on TravisCI."
   export JOBS="$(getconf _NPROCESSORS_ONLN)"
   if [[ "$(uname)" == Darwin ]]; then
     ccache -s
@@ -14,10 +13,8 @@ if [[ $TRAVIS ]]; then
     execute docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache $FULL_TAG
   fi
 elif [[ $BUILDKITE ]]; then
-  echo "This build is running on Buildkite."
   execute ./.cicd/generate-base-images.sh
   execute docker run --rm -v $(pwd):/workdir -e JOBS $FULL_TAG
 else
-  echo "Shouldn't get here."
   exit 1
 fi  

--- a/.cicd/cicd-build.sh
+++ b/.cicd/cicd-build.sh
@@ -15,6 +15,7 @@ if [[ $TRAVIS ]]; then
   fi
 elif [[ $BUILDKITE ]]; then
   echo "This build is running on Buildkite."
+  execute ./.cicd/generate-base-images.sh
   execute docker run --rm -v $(pwd):/workdir -e JOBS $FULL_TAG
 else
   echo "Shouldn't get here."

--- a/.cicd/cicd-build.sh
+++ b/.cicd/cicd-build.sh
@@ -19,4 +19,5 @@ elif [[ $BUILDKITE ]]; then
   execute docker run --rm -v $(pwd):/workdir -e JOBS $FULL_TAG
 else
   echo "Shouldn't get here."
+  exit 1
 fi  

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     command: 
       - "git clone $BUILDKITE_REPO workdir && cd workdir && git submodule update --init --recursive"
       - pwd && ls -la
-      - "cd workdir && bash .cicd/entrypoint.sh"
+      - "cd workdir && bash ./.cicd/travis-build.sh"
     agents: 
       queue: "automation-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -1,78 +1,86 @@
 steps:
-  - wait
-
-
-  - trigger: "eos-vm-base-images-beta"
-    label: ":docker: Docker - Ensure Base Images Exist"
-    build:
-      commit: "${BUILDKITE_COMMIT}"
-      branch: "${BUILDKITE_BRANCH}"
-
-  - wait
 
   - label: ":aws: Amazon_Linux 2 - Build"
-    agents:
+    command: 
+      - "git clone $BUILDKITE_REPO workdir && cd workdir && git submodule update --init --recursive"
+      - pwd && ls -la
+      - "cd workdir && bash .cicd/entrypoint.sh"
+    agents: 
       queue: "automation-eos-builder-fleet"
-    plugins:
-      - docker#v3.3.0:
-          debug: $DEBUG
-          image: "eosio/producer:eos-vm-amazonlinux-2-223f4c6d49e75c04cac442f261e18cda379a463a"
-          environment:
-            - "JOBS"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_AMAZON_LINUX_2
 
-  - label: ":centos: CentOS 7.6 - Build"
-    agents:
-      queue: "automation-eos-builder-fleet"
-    plugins:
-      - docker#v3.3.0:
-          debug: $DEBUG
-          image: "eosio/producer:eos-vm-centos-7.6-b2395f2a78cf42fd8ef2b453e002130eb388423f"
-          environment:
-            - "JOBS"
-    timeout: ${TIMEOUT:-10}
-    skip: $SKIP_CENTOS_7
+  # - trigger: "eos-vm-base-images-beta"
+  #   label: ":docker: Docker - Ensure Base Images Exist"
+  #   build:
+  #     commit: "${BUILDKITE_COMMIT}"
+  #     branch: "${BUILDKITE_BRANCH}"
 
-  - label: ":ubuntu: Ubuntu 16.04 - Build"
-    agents:
-      queue: "automation-eos-builder-fleet"
-    plugins:
-      - docker#v3.3.0:
-          debug: $DEBUG
-          image: "eosio/producer:eos-vm-ubuntu-16.04-320e500c1821d9a5e0030715b1d8c56190429d53"
-          environment:
-            - "JOBS"
-    timeout: ${TIMEOUT:-10}
-    skip: $SKIP_UBUNTU_16
+  # - wait
 
-  - label: ":ubuntu: Ubuntu 18.04 - Build"
-    agents:
-      queue: "automation-eos-builder-fleet"
-    plugins:
-      - docker#v3.3.0:
-          debug: $DEBUG
-          image: "eosio/producer:eos-vm-ubuntu-18.04-bd78cc96ce24726f9ffea8ff88718ce9fb3e7eba"
-          environment:
-            - "JOBS"
-    timeout: ${TIMEOUT:-10}
-    skip: $SKIP_UBUNTU_18
+  # - label: ":aws: Amazon_Linux 2 - Build"
+  #   agents:
+  #     queue: "automation-eos-builder-fleet"
+  #   plugins:
+  #     - docker#v3.3.0:
+  #         debug: $DEBUG
+  #         image: "eosio/producer:eos-vm-amazonlinux-2-223f4c6d49e75c04cac442f261e18cda379a463a"
+  #         environment:
+  #           - "JOBS"
+  #   timeout: ${TIMEOUT:-10}
+  #   skip: $SKIP_AMAZON_LINUX_2
 
-  - label: ":darwin: macOS 10.14 - Build & Test"
-    command:
-      - "brew install git cmake boost"
-      - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git submodule update --init --recursive"
-      - "cd eos-vm && mkdir -p build && cd build && cmake .."
-      - "cd eos-vm/build && make -j$(getconf _NPROCESSORS_ONLN)"
-    plugins:
-      - chef/anka#v0.5.1:
-          no-volume: true
-          inherit-environment-vars: true
-          vm-name: 10.14.4_6C_14G_40G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          modify-cpu: 12
-          modify-ram: 24
-          always-pull: true
-          debug: true
-          wait-network: true
-    agents: "queue=mac-anka-large-node-fleet"
+  # - label: ":centos: CentOS 7.6 - Build"
+  #   agents:
+  #     queue: "automation-eos-builder-fleet"
+  #   plugins:
+  #     - docker#v3.3.0:
+  #         debug: $DEBUG
+  #         image: "eosio/producer:eos-vm-centos-7.6-b2395f2a78cf42fd8ef2b453e002130eb388423f"
+  #         environment:
+  #           - "JOBS"
+  #   timeout: ${TIMEOUT:-10}
+  #   skip: $SKIP_CENTOS_7
+
+  # - label: ":ubuntu: Ubuntu 16.04 - Build"
+  #   agents:
+  #     queue: "automation-eos-builder-fleet"
+  #   plugins:
+  #     - docker#v3.3.0:
+  #         debug: $DEBUG
+  #         image: "eosio/producer:eos-vm-ubuntu-16.04-320e500c1821d9a5e0030715b1d8c56190429d53"
+  #         environment:
+  #           - "JOBS"
+  #   timeout: ${TIMEOUT:-10}
+  #   skip: $SKIP_UBUNTU_16
+
+  # - label: ":ubuntu: Ubuntu 18.04 - Build"
+  #   agents:
+  #     queue: "automation-eos-builder-fleet"
+  #   plugins:
+  #     - docker#v3.3.0:
+  #         debug: $DEBUG
+  #         image: "eosio/producer:eos-vm-ubuntu-18.04-bd78cc96ce24726f9ffea8ff88718ce9fb3e7eba"
+  #         environment:
+  #           - "JOBS"
+  #   timeout: ${TIMEOUT:-10}
+  #   skip: $SKIP_UBUNTU_18
+
+  # - label: ":darwin: macOS 10.14 - Build & Test"
+  #   command:
+  #     - "brew install git cmake boost"
+  #     - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git submodule update --init --recursive"
+  #     - "cd eos-vm && mkdir -p build && cd build && cmake .."
+  #     - "cd eos-vm/build && make -j$(getconf _NPROCESSORS_ONLN)"
+  #   plugins:
+  #     - chef/anka#v0.5.1:
+  #         no-volume: true
+  #         inherit-environment-vars: true
+  #         vm-name: 10.14.4_6C_14G_40G
+  #         vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+  #         modify-cpu: 12
+  #         modify-ram: 24
+  #         always-pull: true
+  #         debug: true
+  #         wait-network: true
+  #   agents: "queue=mac-anka-large-node-fleet"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -2,7 +2,7 @@ steps:
 
   - label: ":aws: Amazon_Linux 2 - Build"
     command:
-      - "bash ./.cicd/travis-build.sh"
+      - "bash ./.cicd/cicd-build.sh"
     env:
       IMAGE_TAG: "amazonlinux-2"
     agents: 
@@ -10,66 +10,40 @@ steps:
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_AMAZON_LINUX_2
 
-  # - trigger: "eos-vm-base-images-beta"
-  #   label: ":docker: Docker - Ensure Base Images Exist"
-  #   build:
-  #     commit: "${BUILDKITE_COMMIT}"
-  #     branch: "${BUILDKITE_BRANCH}"
-
-  # - wait
-
-  # - label: ":aws: Amazon_Linux 2 - Build"
-  #   agents:
-  #     queue: "automation-eos-builder-fleet"
-  #   plugins:
-  #     - docker#v3.3.0:
-  #         debug: $DEBUG
-  #         image: "eosio/producer:eos-vm-amazonlinux-2-223f4c6d49e75c04cac442f261e18cda379a463a"
-  #         environment:
-  #           - "JOBS"
-  #   timeout: ${TIMEOUT:-10}
-  #   skip: $SKIP_AMAZON_LINUX_2
-
   # - label: ":centos: CentOS 7.6 - Build"
-  #   agents:
+  #   command:
+  #     - "bash ./.cicd/travis-build.sh"
+  #   env:
+  #     IMAGE_TAG: "centos-7.6"
+  #   agents: 
   #     queue: "automation-eos-builder-fleet"
-  #   plugins:
-  #     - docker#v3.3.0:
-  #         debug: $DEBUG
-  #         image: "eosio/producer:eos-vm-centos-7.6-b2395f2a78cf42fd8ef2b453e002130eb388423f"
-  #         environment:
-  #           - "JOBS"
   #   timeout: ${TIMEOUT:-10}
   #   skip: $SKIP_CENTOS_7
 
   # - label: ":ubuntu: Ubuntu 16.04 - Build"
-  #   agents:
+  #   command:
+  #     - "bash ./.cicd/travis-build.sh"
+  #   env:
+  #     IMAGE_TAG: "ubuntu-16.04"
+  #   agents: 
   #     queue: "automation-eos-builder-fleet"
-  #   plugins:
-  #     - docker#v3.3.0:
-  #         debug: $DEBUG
-  #         image: "eosio/producer:eos-vm-ubuntu-16.04-320e500c1821d9a5e0030715b1d8c56190429d53"
-  #         environment:
-  #           - "JOBS"
   #   timeout: ${TIMEOUT:-10}
   #   skip: $SKIP_UBUNTU_16
 
   # - label: ":ubuntu: Ubuntu 18.04 - Build"
-  #   agents:
+  #   command:
+  #     - "bash ./.cicd/travis-build.sh"
+  #   env:
+  #     IMAGE_TAG: "ubuntu-18.04"
+  #   agents: 
   #     queue: "automation-eos-builder-fleet"
-  #   plugins:
-  #     - docker#v3.3.0:
-  #         debug: $DEBUG
-  #         image: "eosio/producer:eos-vm-ubuntu-18.04-bd78cc96ce24726f9ffea8ff88718ce9fb3e7eba"
-  #         environment:
-  #           - "JOBS"
   #   timeout: ${TIMEOUT:-10}
   #   skip: $SKIP_UBUNTU_18
 
   # - label: ":darwin: macOS 10.14 - Build & Test"
   #   command:
   #     - "brew install git cmake boost"
-  #     - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_BRANCH && git submodule update --init --recursive"
+  #     - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
   #     - "cd eos-vm && mkdir -p build && cd build && cmake .."
   #     - "cd eos-vm/build && make -j$(getconf _NPROCESSORS_ONLN)"
   #   plugins:

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -2,10 +2,10 @@ steps:
 
   - label: ":aws: Amazon_Linux 2 - Build"
     command: 
-      - pwd && ls -la
+      # - pwd && ls -la
       # - "git clone $BUILDKITE_REPO workdir && cd workdir && git checkout $BUILDKITE_BRANCH && git submodule update --init --recursive"
       # - "pwd && ls -la"
-      # - "bash ./.cicd/travis-build.sh"
+      - "bash ./.cicd/travis-build.sh"
     agents: 
       queue: "automation-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -1,11 +1,10 @@
 steps:
 
   - label: ":aws: Amazon_Linux 2 - Build"
-    command: 
-      # - pwd && ls -la
-      # - "git clone $BUILDKITE_REPO workdir && cd workdir && git checkout $BUILDKITE_BRANCH && git submodule update --init --recursive"
-      # - "pwd && ls -la"
+    command:
       - "bash ./.cicd/travis-build.sh"
+    env:
+      IMAGE_TAG: "amazonlinux-2"
     agents: 
       queue: "automation-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
@@ -70,7 +69,7 @@ steps:
   # - label: ":darwin: macOS 10.14 - Build & Test"
   #   command:
   #     - "brew install git cmake boost"
-  #     - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git submodule update --init --recursive"
+  #     - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_BRANCH && git submodule update --init --recursive"
   #     - "cd eos-vm && mkdir -p build && cd build && cmake .."
   #     - "cd eos-vm/build && make -j$(getconf _NPROCESSORS_ONLN)"
   #   plugins:

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     command: 
       - "git clone $BUILDKITE_REPO workdir && cd workdir && git submodule update --init --recursive"
       - pwd && ls -la
-      - "cd workdir && bash ./.cicd/travis-build.sh"
+      - "bash ./.cicd/travis-build.sh"
     agents: 
       queue: "automation-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,51 +10,51 @@ steps:
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_AMAZON_LINUX_2
 
-  # - label: ":centos: CentOS 7.6 - Build"
-  #   command:
-  #     - "bash ./.cicd/travis-build.sh"
-  #   env:
-  #     IMAGE_TAG: "centos-7.6"
-  #   agents: 
-  #     queue: "automation-eos-builder-fleet"
-  #   timeout: ${TIMEOUT:-10}
-  #   skip: $SKIP_CENTOS_7
+  - label: ":centos: CentOS 7.6 - Build"
+    command:
+      - "bash ./.cicd/travis-build.sh"
+    env:
+      IMAGE_TAG: "centos-7.6"
+    agents: 
+      queue: "automation-eos-builder-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: $SKIP_CENTOS_7
 
-  # - label: ":ubuntu: Ubuntu 16.04 - Build"
-  #   command:
-  #     - "bash ./.cicd/travis-build.sh"
-  #   env:
-  #     IMAGE_TAG: "ubuntu-16.04"
-  #   agents: 
-  #     queue: "automation-eos-builder-fleet"
-  #   timeout: ${TIMEOUT:-10}
-  #   skip: $SKIP_UBUNTU_16
+  - label: ":ubuntu: Ubuntu 16.04 - Build"
+    command:
+      - "bash ./.cicd/travis-build.sh"
+    env:
+      IMAGE_TAG: "ubuntu-16.04"
+    agents: 
+      queue: "automation-eos-builder-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: $SKIP_UBUNTU_16
 
-  # - label: ":ubuntu: Ubuntu 18.04 - Build"
-  #   command:
-  #     - "bash ./.cicd/travis-build.sh"
-  #   env:
-  #     IMAGE_TAG: "ubuntu-18.04"
-  #   agents: 
-  #     queue: "automation-eos-builder-fleet"
-  #   timeout: ${TIMEOUT:-10}
-  #   skip: $SKIP_UBUNTU_18
+  - label: ":ubuntu: Ubuntu 18.04 - Build"
+    command:
+      - "bash ./.cicd/travis-build.sh"
+    env:
+      IMAGE_TAG: "ubuntu-18.04"
+    agents: 
+      queue: "automation-eos-builder-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: $SKIP_UBUNTU_18
 
-  # - label: ":darwin: macOS 10.14 - Build & Test"
-  #   command:
-  #     - "brew install git cmake boost"
-  #     - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
-  #     - "cd eos-vm && mkdir -p build && cd build && cmake .."
-  #     - "cd eos-vm/build && make -j$(getconf _NPROCESSORS_ONLN)"
-  #   plugins:
-  #     - chef/anka#v0.5.1:
-  #         no-volume: true
-  #         inherit-environment-vars: true
-  #         vm-name: 10.14.4_6C_14G_40G
-  #         vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-  #         modify-cpu: 12
-  #         modify-ram: 24
-  #         always-pull: true
-  #         debug: true
-  #         wait-network: true
-  #   agents: "queue=mac-anka-large-node-fleet"
+  - label: ":darwin: macOS 10.14 - Build & Test"
+    command:
+      - "brew install git cmake boost"
+      - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "cd eos-vm && mkdir -p build && cd build && cmake .."
+      - "cd eos-vm/build && make -j$(getconf _NPROCESSORS_ONLN)"
+    plugins:
+      - chef/anka#v0.5.1:
+          no-volume: true
+          inherit-environment-vars: true
+          vm-name: 10.14.4_6C_14G_40G
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+          modify-cpu: 12
+          modify-ram: 24
+          always-pull: true
+          debug: true
+          wait-network: true
+    agents: "queue=mac-anka-large-node-fleet"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -2,8 +2,8 @@ steps:
 
   - label: ":aws: Amazon_Linux 2 - Build"
     command: 
-      - "git clone $BUILDKITE_REPO workdir && cd workdir && git submodule update --init --recursive"
-      - pwd && ls -la
+      - "git clone $BUILDKITE_REPO workdir && cd workdir && git checkout $BUILDKITE_BRANCH && git submodule update --init --recursive"
+      - "pwd && ls -la"
       - "bash ./.cicd/travis-build.sh"
     agents: 
       queue: "automation-eos-builder-fleet"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -12,7 +12,7 @@ steps:
 
   - label: ":centos: CentOS 7.6 - Build"
     command:
-      - "bash ./.cicd/travis-build.sh"
+      - "bash ./.cicd/cicd-build.sh"
     env:
       IMAGE_TAG: "centos-7.6"
     agents: 
@@ -22,7 +22,7 @@ steps:
 
   - label: ":ubuntu: Ubuntu 16.04 - Build"
     command:
-      - "bash ./.cicd/travis-build.sh"
+      - "bash ./.cicd/cicd-build.sh"
     env:
       IMAGE_TAG: "ubuntu-16.04"
     agents: 
@@ -32,7 +32,7 @@ steps:
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
     command:
-      - "bash ./.cicd/travis-build.sh"
+      - "bash ./.cicd/cicd-build.sh"
     env:
       IMAGE_TAG: "ubuntu-18.04"
     agents: 

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -2,9 +2,10 @@ steps:
 
   - label: ":aws: Amazon_Linux 2 - Build"
     command: 
-      - "git clone $BUILDKITE_REPO workdir && cd workdir && git checkout $BUILDKITE_BRANCH && git submodule update --init --recursive"
-      - "pwd && ls -la"
-      - "bash ./.cicd/travis-build.sh"
+      - pwd && ls -la
+      # - "git clone $BUILDKITE_REPO workdir && cd workdir && git checkout $BUILDKITE_BRANCH && git submodule update --init --recursive"
+      # - "pwd && ls -la"
+      # - "bash ./.cicd/travis-build.sh"
     agents: 
       queue: "automation-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}

--- a/.cicd/travis-build.sh
+++ b/.cicd/travis-build.sh
@@ -2,13 +2,18 @@
 set -eo pipefail
 . ./.cicd/execute.sh
 . ./.cicd/docker-hash.sh
-export JOBS="$(getconf _NPROCESSORS_ONLN)"
-if [[ "$(uname)" == Darwin ]]; then
-	mkdir build
-	cd build
-	execute ccache -s
-	execute cmake ..
-	execute make -j$JOBS
-else # linux
-	execute docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache $FULL_TAG
-fi
+
+if [[ $TRAVIS ]]; then
+  echo "This build is running on TravisCI."
+elif [[ $BUILDKITE ]]; then
+  echo "This build is running on Buildkite."
+else
+  echo "Shouldn't get here."
+fi  
+# if [[ "$(uname)" == Darwin ]]; then
+#   ccache -s
+#   mkdir -p build && cd build && cmake ..
+#   make -j$(getconf _NPROCESSORS_ONLN)
+# else # linux
+#   execute docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e CCACHE_DIR=/opt/.ccache $FULL_TAG
+# fi

--- a/.cicd/travis-build.sh
+++ b/.cicd/travis-build.sh
@@ -5,15 +5,17 @@ set -eo pipefail
 
 if [[ $TRAVIS ]]; then
   echo "This build is running on TravisCI."
+  export JOBS="$(getconf _NPROCESSORS_ONLN)"
+  if [[ "$(uname)" == Darwin ]]; then
+    ccache -s
+    mkdir -p build && cd build && cmake ..
+    make -j$JOBS
+  else # linux
+    execute docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e JOBS -e CCACHE_DIR=/opt/.ccache $FULL_TAG
+  fi
 elif [[ $BUILDKITE ]]; then
   echo "This build is running on Buildkite."
+  execute docker run --rm -v $(pwd):/workdir -e JOBS $FULL_TAG
 else
   echo "Shouldn't get here."
 fi  
-# if [[ "$(uname)" == Darwin ]]; then
-#   ccache -s
-#   mkdir -p build && cd build && cmake ..
-#   make -j$(getconf _NPROCESSORS_ONLN)
-# else # linux
-#   execute docker run --rm -v $(pwd):/workdir -v /usr/lib/ccache -v $HOME/.ccache:/opt/.ccache -e CCACHE_DIR=/opt/.ccache $FULL_TAG
-# fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
           packages:
             - boost@1.70
             - ccache
-script: "./.cicd/travis-build.sh"
+script: "./.cicd/cicd-build.sh"
 notifications:
   webhooks:
     secure: n0VHgAzeIqcnitJBX+UMdrnbUZQ3Nh/CvVj2I4E5FhjoolzM0pRmnPQ4h6BQ/QwTdGPh1AbitDDDGRCSGtZH2erp9OFv+gePZyaRN/+h0Q3Ak8hwfqr7UoEUcJuPFA6S42TduCs6Kn+1XnL5g2OZYAmlS9+H7MvjUqFloa0YL/F8RJ4rvXVtMsHbC6bKXSBwVROU8G4rq8zNnNShL91i5xakhywfLkhgmRM/xuL4I+7+5LXJwOvnQMQnyL55NdREmvvwJqjHNBPvjTe1Rm2xQpC5+gxW2ZaqtjuulwY/IJgWWhUlJhrZTiBpf6v3camqdFxAjA+7fGDiZNXGe4xgZuEojj++2oM6orGhGc58Pr015lxGgcLF7d7+sqINCEnTVtleSC7czsnkcpONVOyi9BW2Gyxjaf2EN09/XH3QzH093WkOeEhREwMUo7Xa2ugu/svnqp890FTgGftUY0dJkOP8v3y+sU9DQ9/CwcsRIzFBfoZFOL0OySM9+nH4Ervkf5z8n1ikGHjE6xv63P1nV7SmrTjnIGgJ60xYFtPgV0ELBmy4cbVF86Jcr8KrTPhna3wgXX80g8UOgZlVIUOErvhJWxThW6wz2PO07QU5Y+caz0zrL2c7AuXXn5BQjtMPBSIomOybgFyrP0Yf6qKBXTV4Y3qEpiYa/PkZvxUsT6U=


### PR DESCRIPTION
* Replaced the Docker plugin for Buildkite with changes to `./.cicd/cicd-build.sh` (formally `./.cicd/travis-build.sh`)
** This script now conditionally determines if it was launched from Travis or Buildkite. If Travis, just run a build. If Buildkite, ensure the Dockerhub image exists before running the build.
** This eliminates needing to update `pipeline.yml`each time a new Dockerhub image is created.