### PR TITLE
Fix for #82

### DIFF
--- a/include/eosio/vm/stack_elem.hpp
+++ b/include/eosio/vm/stack_elem.hpp
@@ -12,25 +12,25 @@ namespace eosio { namespace vm {
    class operand_stack_elem : public variant<i32_const_t, i64_const_t, f32_const_t, f64_const_t> {
       public:
          using variant<i32_const_t, i64_const_t, f32_const_t, f64_const_t>::variant;
-         inline int32_t&  to_i32() { return get<i32_const_t>().data.i; }
-         inline uint32_t& to_ui32() { return get<i32_const_t>().data.ui; }
-         inline float&    to_f32() { return get<f32_const_t>().data.f; }
-         inline uint32_t& to_fui32() { return get<f32_const_t>().data.ui; }
+         inline int32_t&  to_i32() & { return get<i32_const_t>().data.i; }
+         inline uint32_t& to_ui32() & { return get<i32_const_t>().data.ui; }
+         inline float&    to_f32() & { return get<f32_const_t>().data.f; }
+         inline uint32_t& to_fui32() & { return get<f32_const_t>().data.ui; }
 
-         inline int64_t&  to_i64() { return get<i64_const_t>().data.i; }
-         inline uint64_t& to_ui64() { return get<i64_const_t>().data.ui; }
-         inline double&   to_f64() { return get<f64_const_t>().data.f; }
-         inline uint64_t& to_fui64() { return get<f64_const_t>().data.ui; }
+         inline int64_t&  to_i64() & { return get<i64_const_t>().data.i; }
+         inline uint64_t& to_ui64() & { return get<i64_const_t>().data.ui; }
+         inline double&   to_f64() & { return get<f64_const_t>().data.f; }
+         inline uint64_t& to_fui64() & { return get<f64_const_t>().data.ui; }
 
-         inline int32_t  to_i32() const { return get<i32_const_t>().data.i; }
-         inline uint32_t to_ui32() const { return get<i32_const_t>().data.ui; }
-         inline float    to_f32() const { return get<f32_const_t>().data.f; }
-         inline uint32_t to_fui32() const { return get<f32_const_t>().data.ui; }
+         inline int32_t  to_i32() const & { return get<i32_const_t>().data.i; }
+         inline uint32_t to_ui32() const & { return get<i32_const_t>().data.ui; }
+         inline float    to_f32() const & { return get<f32_const_t>().data.f; }
+         inline uint32_t to_fui32() const & { return get<f32_const_t>().data.ui; }
 
-         inline int64_t  to_i64() const { return get<i64_const_t>().data.i; }
-         inline uint64_t to_ui64() const { return get<i64_const_t>().data.ui; }
-         inline double   to_f64() const { return get<f64_const_t>().data.f; }
-         inline uint64_t to_fui64() const { return get<f64_const_t>().data.ui; }
+         inline int64_t  to_i64() const & { return get<i64_const_t>().data.i; }
+         inline uint64_t to_ui64() const & { return get<i64_const_t>().data.ui; }
+         inline double   to_f64() const & { return get<f64_const_t>().data.f; }
+         inline uint64_t to_fui64() const & { return get<f64_const_t>().data.ui; }
 
    };
 }} // nameo::vm

--- a/tests/host_functions_tests.cpp
+++ b/tests/host_functions_tests.cpp
@@ -374,10 +374,10 @@ BACKEND_TEST_CASE( "Test C-style host function system", "[C-style_host_functions
    CHECK(c_style_host_function_state == 3);
 
    float f = 2.4f;
-   bkend.call(nullptr, "env", "apply", (uint64_t)3, (uint64_t)2, *(uint64_t*)&f);
+   bkend.call(nullptr, "env", "apply", (uint64_t)3, (uint64_t)2, (uint64_t)bit_cast<uint32_t>(f));
    CHECK(c_style_host_function_state == 0x40199980);
 
-   bkend.call(nullptr, "env", "apply", (uint64_t)4, (uint64_t)5, *(uint64_t*)&f);
+   bkend.call(nullptr, "env", "apply", (uint64_t)4, (uint64_t)5, (uint64_t)bit_cast<uint32_t>(f));
    CHECK(c_style_host_function_state == 5);
 }
 


### PR DESCRIPTION
We were binding a reference to a temporary.  Passing it through to_i64 prevents lifetime extension.