### PR TITLE
CI/CD support for Catalina

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -63,6 +63,25 @@ steps:
           wait-network: true
     agents: "queue=mac-anka-large-node-fleet"
 
+  - label: ":darwin: macOS 10.15 - Build"
+    command:
+      - "brew install git cmake"
+      - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "cd eos-vm && ./.cicd/build.sh"
+      - "cd eos-vm && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
+    plugins:
+      - chef/anka#v0.5.1:
+          no-volume: true
+          inherit-environment-vars: true
+          vm-name: 10.15.0_6C_14G_40G
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+          modify-cpu: 12
+          modify-ram: 24
+          always-pull: true
+          debug: true
+          wait-network: true
+    agents: "queue=mac-anka-large-node-fleet"
+
   - wait
 
   - label: ":aws: Amazon_Linux 2 - Test"
@@ -120,6 +139,23 @@ steps:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_40G
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+          always-pull: true
+          debug: true
+          wait-network: true
+    agents: "queue=mac-anka-node-fleet"
+
+  - label: ":darwin: macOS 10.15 - Tests"
+    command:
+      - "brew install git cmake"
+      - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "cd eos-vm && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.15 - Build' && tar -xzf build.tar.gz"
+      - "cd eos-vm && ./.cicd/tests.sh"
+    plugins:
+      - chef/anka#v0.5.1:
+          no-volume: true
+          inherit-environment-vars: true
+          vm-name: 10.15.0_6C_14G_40G
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
           always-pull: true
           debug: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -62,6 +62,7 @@ steps:
           debug: true
           wait-network: true
     agents: "queue=mac-anka-large-node-fleet"
+    skip: $SKIP_MACOS_10_14
 
   - label: ":darwin: macOS 10.15 - Build"
     command:
@@ -81,6 +82,7 @@ steps:
           debug: true
           wait-network: true
     agents: "queue=mac-anka-large-node-fleet"
+    skip: $SKIP_MACOS_10_15
 
   - wait
 
@@ -144,6 +146,7 @@ steps:
           debug: true
           wait-network: true
     agents: "queue=mac-anka-node-fleet"
+    skip: $SKIP_MACOS_10_14
 
   - label: ":darwin: macOS 10.15 - Tests"
     command:
@@ -161,6 +164,7 @@ steps:
           debug: true
           wait-network: true
     agents: "queue=mac-anka-node-fleet"
+    skip: $SKIP_MACOS_10_15
 
   - wait:
     continue_on_failure: true


### PR DESCRIPTION
Added new Catalina 10.15.0 to the Buildkite CI pipelines.

Added SKIP_MACOS_10_15/14 to match what we use for EOSIO.