### PR TITLE
[Develop] CI/CD: switch from gke to eks

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -72,7 +72,7 @@ steps:
     env:
       IMAGE_TAG: "amazonlinux-2"
     agents: 
-      queue: "automation-eks-eos-tester-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_AMAZON_LINUX_2
 
@@ -83,7 +83,7 @@ steps:
     env:
       IMAGE_TAG: "centos-7.6"
     agents: 
-      queue: "automation-eks-eos-tester-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_CENTOS_7
 
@@ -94,7 +94,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-16.04"
     agents: 
-      queue: "automation-eks-eos-tester-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_UBUNTU_16
 
@@ -105,7 +105,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-18.04"
     agents: 
-      queue: "automation-eks-eos-tester-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_UBUNTU_18
 
@@ -136,6 +136,6 @@ steps:
       echo '+++ :javascript: Running test-metrics.js'
       node --max-old-space-size=32768 test-metrics.js
     agents:
-      queue: "automation-eks-eos-tester-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: 10
     soft_fail: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -7,7 +7,7 @@ steps:
     env:
       IMAGE_TAG: "amazonlinux-2"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_AMAZON_LINUX_2
 
@@ -18,7 +18,7 @@ steps:
     env:
       IMAGE_TAG: "centos-7.6"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_CENTOS_7
 
@@ -29,7 +29,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-16.04"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_UBUNTU_16
 
@@ -40,7 +40,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-18.04"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_UBUNTU_18
 
@@ -72,7 +72,7 @@ steps:
     env:
       IMAGE_TAG: "amazonlinux-2"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-tester-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_AMAZON_LINUX_2
 
@@ -83,7 +83,7 @@ steps:
     env:
       IMAGE_TAG: "centos-7.6"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-tester-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_CENTOS_7
 
@@ -94,7 +94,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-16.04"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-tester-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_UBUNTU_16
 
@@ -105,7 +105,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-18.04"
     agents: 
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-tester-fleet"
     timeout: ${TIMEOUT:-10}
     skip: $SKIP_UBUNTU_18
 
@@ -136,6 +136,6 @@ steps:
       echo '+++ :javascript: Running test-metrics.js'
       node --max-old-space-size=32768 test-metrics.js
     agents:
-      queue: "automation-eos-builder-fleet"
+      queue: "automation-eks-eos-tester-fleet"
     timeout: 10
     soft_fail: true


### PR DESCRIPTION
Migration from GKE builders/testers to EKS. This will allow us to scale and maintain these machines much easier.

They're also faster. We see almost half the time for builds in several pipelines (contracts went from 7m to 4m).