### PR TITLE
Add max_code_size and the two dynamic config options: max_pages and m…

### DIFF
--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -53,14 +53,16 @@ namespace eosio { namespace vm {
 
       template <typename HostFunctions = nullptr_t>
       backend(wasm_code& code, HostFunctions = nullptr, const Options& options = Options{})
-        : _ctx(typename Impl::template parser<Host, Options>{ _mod.allocator, options }.parse_module(code, _mod)) {
+        : _ctx(typename Impl::template parser<Host, Options>{ _mod.allocator, options }.parse_module(code, _mod), detail::get_max_call_depth(options)) {
+         _ctx.set_max_pages(detail::get_max_pages(options));
 	 _mod.finalize();
 	 if constexpr (!std::is_same_v<HostFunctions, nullptr_t>)
             HostFunctions::resolve(_mod);
       }
       template <typename HostFunctions = nullptr_t>
       backend(wasm_code_ptr& ptr, size_t sz, HostFunctions = nullptr, const Options& options = Options{})
-        : _ctx(typename Impl::template parser<Host, Options>{ _mod.allocator, options }.parse_module2(ptr, sz, _mod)) {
+        : _ctx(typename Impl::template parser<Host, Options>{ _mod.allocator, options }.parse_module2(ptr, sz, _mod), detail::get_max_call_depth(options)) {
+         _ctx.set_max_pages(detail::get_max_pages(options));
 	 _mod.finalize();
 	 if constexpr (!std::is_same_v<HostFunctions, nullptr_t>)
             HostFunctions::resolve(_mod);
@@ -69,6 +71,14 @@ namespace eosio { namespace vm {
       template <typename... Args>
       inline bool operator()(Host* host, const std::string_view& mod, const std::string_view& func, Args... args) {
          return call(host, mod, func, args...);
+      }
+
+      // Only dynamic options matter.  Parser options will be ignored.
+      inline backend& initialize(Host* host, const Options& new_options) {
+         _ctx.set_max_call_depth(detail::get_max_call_depth(new_options));
+         _ctx.set_max_pages(detail::get_max_pages(new_options));
+         initialize(host);
+         return *this;
       }
 
       inline backend& initialize(Host* host=nullptr) {

--- a/include/eosio/vm/constants.hpp
+++ b/include/eosio/vm/constants.hpp
@@ -13,7 +13,7 @@ namespace eosio { namespace vm {
       initial_stack_size    = 8*1024,
       initial_module_size   = 1 * 1024 * 1024,
       max_memory            = 4ull << 31,
-      max_useable_memory    = (33 * 1024 * 1024), //33mb
+      max_useable_memory    = (1ull << 32), //4GiB
       page_size             = 64ull * 1024, //64kb
       max_pages             = (max_useable_memory/page_size)
    };

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -38,7 +38,7 @@ namespace eosio { namespace vm {
                return -1;
             _wasm_alloc->free<char>(-pages);
          } else {
-            if (!_mod.memories.size() || max_pages - sz < pages ||
+            if (!_mod.memories.size() || _max_pages - sz < pages ||
                 (_mod.memories[0].limits.flags && (static_cast<int32_t>(_mod.memories[0].limits.maximum) - sz < pages)))
                return -1;
             _wasm_alloc->alloc<char>(pages);
@@ -57,6 +57,7 @@ namespace eosio { namespace vm {
       inline void           set_wasm_allocator(wasm_allocator* alloc) { _wasm_alloc = alloc; }
       inline auto           get_wasm_allocator() { return _wasm_alloc; }
       inline char*          linear_memory() { return _linear_memory; }
+      void                  set_max_pages(std::uint32_t max_pages) { _max_pages = std::min(max_pages, static_cast<std::uint32_t>(vm::max_pages)); }
 
       inline std::error_code get_error_code() const { return _error_code; }
 
@@ -124,6 +125,7 @@ namespace eosio { namespace vm {
       char*                           _linear_memory    = nullptr;
       module&                         _mod;
       wasm_allocator*                 _wasm_alloc;
+      uint32_t                        _max_pages = max_pages;
       registered_host_functions<Host> _rhf;
       std::error_code                 _error_code;
    };
@@ -134,7 +136,7 @@ namespace eosio { namespace vm {
    class null_execution_context : public execution_context_base<null_execution_context<Host>, Host> {
       using base_type = execution_context_base<null_execution_context<Host>, Host>;
    public:
-      using base_type::base_type;
+      null_execution_context(module& m, std::uint32_t max_call_depth) : base_type(m) {}
    };
 
    template<typename Host>
@@ -148,6 +150,12 @@ namespace eosio { namespace vm {
       using base_type::_rhf;
       using base_type::_error_code;
       using base_type::handle_signal;
+
+      jit_execution_context(module& m, std::uint32_t max_call_depth) : base_type(m), _remaining_call_depth(max_call_depth) {}
+
+      void set_max_call_depth(std::uint32_t max_call_depth) {
+         _remaining_call_depth = max_call_depth;
+      }
 
       inline operand_stack& get_operand_stack() { return _os; }
 
@@ -256,7 +264,7 @@ namespace eosio { namespace vm {
       static native_value execute(native_value* data, native_value (*fun)(void*, void*), jit_execution_context* context, void* linear_memory, void* stack) {
          static_assert(sizeof(native_value) == 8, "8-bytes expected for native_value");
          native_value result;
-         unsigned stack_check = constants::max_call_depth + 1;
+         unsigned stack_check = context->_remaining_call_depth;
          register void* stack_top asm ("r12") = stack;
          // 0x1f80 is the default MXCSR value
          asm volatile(
@@ -305,6 +313,7 @@ namespace eosio { namespace vm {
       }
 
       Host * _host = nullptr;
+      uint32_t _remaining_call_depth;
 
       // This is only needed because the host function api uses operand stack
       operand_stack _os;
@@ -319,8 +328,21 @@ namespace eosio { namespace vm {
       using base_type::_linear_memory;
       using base_type::_error_code;
       using base_type::handle_signal;
-      execution_context(module& m) : base_type(m), _halt(exit_t{}) {}
+      execution_context(module& m, uint32_t max_call_depth)
+       : base_type(m), _base_allocator{max_call_depth*sizeof(activation_frame)},
+         _as{max_call_depth, _base_allocator}, _halt(exit_t{}) {}
 
+      void set_max_call_depth(uint32_t max_call_depth) {
+         static_assert(std::is_trivially_move_assignable_v<call_stack>, "This is seriously broken if call_stack move assignment might use the existing memory");
+         std::size_t mem_size = max_call_depth*sizeof(activation_frame);
+         if(mem_size > _base_allocator.mem_size) {
+            _base_allocator = bounded_allocator{mem_size};
+            _as = call_stack{max_call_depth, _base_allocator};
+         } else if (max_call_depth != _as.capacity()){
+            _base_allocator.index = 0;
+            _as = call_stack{max_call_depth, _base_allocator};
+         }
+      }
 
       inline void call(uint32_t index) {
          // TODO validate index is valid

--- a/include/eosio/vm/options.hpp
+++ b/include/eosio/vm/options.hpp
@@ -26,7 +26,14 @@ struct options {
    std::uint32_t max_br_table_elements;
    // The maximum length of symbols used for import and export
    std::uint32_t max_symbol_bytes;
+   // The maximum offset used for load and store
    std::uint32_t max_memory_offset;
+   // The maximum size of a function body
+   std::uint32_t max_code_bytes;
+   // The maximum size of linear memory in page units.
+   std::uint32_t max_pages;
+   // The maximum function call depth
+   std::uint32_t max_call_depth;
    // Can mutable globals be exported
    bool forbid_export_mutable_globals = false;
    // Very strange non-conforming behavior
@@ -57,6 +64,8 @@ struct eosio_options {
    static constexpr std::uint32_t max_br_table_elements = 8191;
    static constexpr std::uint32_t max_symbol_bytes = 8191;
    static constexpr std::uint32_t max_memory_offset = (33*1024*1024 - 1);
+   static constexpr std::uint32_t max_pages = 528; // 33 MiB
+   static constexpr std::uint32_t max_call_depth = 251;
 
    static constexpr bool forbid_export_mutable_globals = true;
    static constexpr bool allow_code_after_function_end = true;

--- a/include/eosio/vm/parser.hpp
+++ b/include/eosio/vm/parser.hpp
@@ -132,6 +132,9 @@ namespace eosio { namespace vm {
 
    MAX_ELEMENTS(max_symbol_bytes, 0xFFFFFFFFu)
    MAX_ELEMENTS(max_memory_offset, 0xFFFFFFFFu)
+   MAX_ELEMENTS(max_code_bytes, 0xFFFFFFFFu)
+   MAX_ELEMENTS(max_pages, 0xFFFFFFFFu)
+   MAX_ELEMENTS(max_call_depth, 251)
 
    PARSER_OPTION(forbid_export_mutable_globals, false, bool);
    PARSER_OPTION(allow_code_after_function_end, false, bool);
@@ -362,7 +365,7 @@ namespace eosio { namespace vm {
          mt.limits.flags   = parse_flags(code);
          mt.limits.initial = parse_varuint32(code);
          // Implementation limits
-         EOS_VM_ASSERT(mt.limits.initial <= max_pages, wasm_parse_exception, "initial memory out of range");
+         EOS_VM_ASSERT(mt.limits.initial <= detail::get_max_pages(_options), wasm_parse_exception, "initial memory out of range");
          // WASM specification
          EOS_VM_ASSERT(mt.limits.initial <= 65536u, wasm_parse_exception, "initial memory out of range");
          if (mt.limits.flags) {
@@ -460,6 +463,7 @@ namespace eosio { namespace vm {
 
       void parse_function_body(wasm_code_ptr& code, function_body& fb, std::size_t idx) {
          fb.size   = parse_varuint32(code);
+         EOS_VM_ASSERT(fb.size <= detail::get_max_code_bytes(_options), wasm_parse_exception, "Function body too large");
          const auto&         before    = code.offset();
          const auto&         local_cnt = parse_varuint32(code);
          _current_function_index++;

--- a/include/eosio/vm/wasm_stack.hpp
+++ b/include/eosio/vm/wasm_stack.hpp
@@ -20,8 +20,12 @@ namespace eosio { namespace vm {
          : _store(ElemSz) {}
 
       template <typename Alloc=Allocator, typename = std::enable_if_t<!std::is_same_v<Alloc, nullptr_t>, int>>
-      stack(Alloc&& alloc) 
+      stack(Alloc&& alloc)
          : _store(alloc, ElemSz) {}
+
+      template <typename Alloc=Allocator, typename = std::enable_if_t<!std::is_same_v<Alloc, nullptr_t>, int>>
+      stack(uint32_t n, Alloc&& alloc)
+         : _store(alloc, n) {}
 
       void push(ElemT&& e) { 
          if constexpr (std::is_same_v<Allocator, nullptr_t>) {
@@ -54,6 +58,7 @@ namespace eosio { namespace vm {
       ElemT        get_back(size_t i) { return _store[_index - 1 - i]; }
       void         trim(size_t amt) { _index -= amt; }
       size_t       size() const { return _index; }
+      size_t       capacity() const { return _store.size(); }
 
     private:
       using base_data_store_t = std::conditional_t<std::is_same_v<Allocator, nullptr_t>, unmanaged_vector<ElemT>, managed_vector<ElemT, Allocator>>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,12 +90,14 @@ add_executable(unit_tests main.cpp
                           allow_u32_limits_flags_tests.cpp
                           forbid_export_mutable_globals_tests.cpp
                           max_br_table_elements_tests.cpp
+                          max_code_bytes_tests.cpp
                           max_func_local_bytes_tests.cpp
                           max_linear_memory_init_tests.cpp
                           max_local_sets_tests.cpp
                           max_memory_offset_tests.cpp
                           max_mutable_globals_tests.cpp
                           max_nested_structures_tests.cpp
+                          max_pages_tests.cpp
                           max_section_elements_tests.cpp
                           max_table_elements_tests.cpp
                           null_tests.cpp

--- a/tests/implementation_limits_tests.cpp
+++ b/tests/implementation_limits_tests.cpp
@@ -18,9 +18,17 @@ void host_call() {}
 
 #include "implementation_limits.hpp"
 
+namespace {
+
 wasm_code implementation_limits_wasm_code{
    implementation_limits_wasm + 0,
    implementation_limits_wasm + sizeof(implementation_limits_wasm)};
+
+struct dynamic_options {
+   std::uint32_t max_call_depth;
+};
+
+}
 
 BACKEND_TEST_CASE( "Test call depth", "[call_depth]") {
    wasm_allocator wa;
@@ -43,4 +51,39 @@ BACKEND_TEST_CASE( "Test call depth", "[call_depth]") {
    CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.host", (uint32_t)250), std::exception);
    CHECK(!bkend.call_with_return(nullptr, "env", "call.indirect.host", (uint32_t)249));
    CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.indirect.host", (uint32_t)250), std::exception);
+}
+
+BACKEND_TEST_CASE( "Test call depth dynamic", "[call_depth]") {
+   wasm_allocator wa;
+   using backend_t = eosio::vm::backend<nullptr_t, TestType, dynamic_options>;
+   using rhf_t     = eosio::vm::registered_host_functions<nullptr_t>;
+   rhf_t::add<nullptr_t, &host_call, wasm_allocator>("env", "host.call");
+
+   backend_t bkend(implementation_limits_wasm_code, nullptr, dynamic_options{151});
+   bkend.set_wasm_allocator(&wa);
+   bkend.initialize(nullptr);
+
+   rhf_t::resolve(bkend.get_module());
+
+   CHECK(!bkend.call_with_return(nullptr, "env", "call", (uint32_t)150));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call", (uint32_t)151), std::exception);
+   CHECK(!bkend.call_with_return(nullptr, "env", "call.indirect", (uint32_t)150));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.indirect", (uint32_t)151), std::exception);
+   // The host call is added to the recursive function, so we have one fewer frames
+   CHECK(!bkend.call_with_return(nullptr, "env", "call.host", (uint32_t)149));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.host", (uint32_t)150), std::exception);
+   CHECK(!bkend.call_with_return(nullptr, "env", "call.indirect.host", (uint32_t)149));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.indirect.host", (uint32_t)150), std::exception);
+
+   bkend.initialize(nullptr, dynamic_options{51});
+
+   CHECK(!bkend.call_with_return(nullptr, "env", "call", (uint32_t)50));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call", (uint32_t)51), std::exception);
+   CHECK(!bkend.call_with_return(nullptr, "env", "call.indirect", (uint32_t)50));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.indirect", (uint32_t)51), std::exception);
+   // The host call is added to the recursive function, so we have one fewer frames
+   CHECK(!bkend.call_with_return(nullptr, "env", "call.host", (uint32_t)49));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.host", (uint32_t)50), std::exception);
+   CHECK(!bkend.call_with_return(nullptr, "env", "call.indirect.host", (uint32_t)49));
+   CHECK_THROWS_AS(bkend.call(nullptr, "env", "call.indirect.host", (uint32_t)50), std::exception);
 }

--- a/tests/max_code_bytes_tests.cpp
+++ b/tests/max_code_bytes_tests.cpp
@@ -1,0 +1,64 @@
+#include <eosio/vm/backend.hpp>
+
+#include "utils.hpp"
+#include <catch2/catch.hpp>
+
+using namespace eosio::vm;
+
+extern wasm_allocator wa;
+
+namespace {
+
+/*
+ * (module
+ *   (func (local i32))
+ * )
+ */
+std::vector<uint8_t> func_wasm = {
+   0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60,
+   0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x01, 0x01,
+   0x7f, 0x0b
+};
+
+struct empty_options {};
+struct static_options_3 {
+   static constexpr std::uint32_t max_code_bytes = 3;
+};
+struct static_options_4 {
+   static constexpr std::uint32_t max_code_bytes = 4;
+};
+struct dynamic_options {
+   std::uint32_t max_code_bytes;
+};
+
+}
+
+BACKEND_TEST_CASE("Test max_code_bytes default", "[max_code_bytes_test]") {
+   using backend_t = backend<std::nullptr_t, TestType>;
+   backend_t backend(func_wasm);
+}
+
+BACKEND_TEST_CASE("Test max_code_bytes unlimited", "[max_code_bytes_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, empty_options>;
+   backend_t backend(func_wasm);
+}
+
+BACKEND_TEST_CASE("Test max_code_bytes static fail", "[max_code_bytes_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, static_options_3>;
+   CHECK_THROWS_AS(backend_t(func_wasm), wasm_parse_exception);
+}
+
+BACKEND_TEST_CASE("Test max_code_bytes static pass", "[max_code_bytes_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, static_options_4>;
+   backend_t backend(func_wasm);
+}
+
+BACKEND_TEST_CASE("Test max_code_bytes dynamic fail", "[max_code_bytes_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, dynamic_options>;
+   CHECK_THROWS_AS(backend_t(func_wasm, nullptr, dynamic_options{3}), wasm_parse_exception);
+}
+
+BACKEND_TEST_CASE("Test max_code_bytes dynamic pass", "[max_code_bytes_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, dynamic_options>;
+   backend_t backend(func_wasm, nullptr, dynamic_options{4});
+}

--- a/tests/max_pages_tests.cpp
+++ b/tests/max_pages_tests.cpp
@@ -1,0 +1,79 @@
+#include <eosio/vm/backend.hpp>
+
+#include "utils.hpp"
+#include <catch2/catch.hpp>
+
+using namespace eosio::vm;
+
+extern wasm_allocator wa;
+
+namespace {
+
+/*
+ * (module
+ *   (memory 3 6)
+ *   (func (export "f") (result i32)
+ *     (i32.const 1)
+ *     (memory.grow)
+ *   )
+ * )
+ */
+std::vector<uint8_t> mem_wasm = {
+   0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+   0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x05, 0x04, 0x01, 0x01, 0x03,
+   0x06, 0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00, 0x0a, 0x08, 0x01, 0x06,
+   0x00, 0x41, 0x01, 0x40, 0x00, 0x0b
+};
+
+struct empty_options {};
+struct static_options_2 {
+   static constexpr std::uint32_t max_pages = 2;
+};
+struct static_options_3 {
+   static constexpr std::uint32_t max_pages = 3;
+};
+struct dynamic_options {
+   std::uint32_t max_pages;
+};
+
+}
+
+BACKEND_TEST_CASE("Test max_pages default", "[max_pages_test]") {
+   using backend_t = backend<std::nullptr_t, TestType>;
+   backend_t backend(mem_wasm);
+}
+
+BACKEND_TEST_CASE("Test max_pages unlimited", "[max_pages_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, empty_options>;
+   backend_t backend(mem_wasm);
+}
+
+BACKEND_TEST_CASE("Test max_pages static fail", "[max_pages_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, static_options_2>;
+   CHECK_THROWS_AS(backend_t(mem_wasm), wasm_parse_exception);
+}
+
+BACKEND_TEST_CASE("Test max_pages static pass", "[max_pages_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, static_options_3>;
+   backend_t backend(mem_wasm);
+   backend.set_wasm_allocator(&wa);
+   backend.initialize();
+   CHECK(backend.call_with_return(nullptr, "env", "f")->to_i32() == -1);
+}
+
+BACKEND_TEST_CASE("Test max_pages dynamic fail", "[max_pages_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, dynamic_options>;
+   CHECK_THROWS_AS(backend_t(mem_wasm, nullptr, dynamic_options{2}), wasm_parse_exception);
+}
+
+BACKEND_TEST_CASE("Test max_pages dynamic pass", "[max_pages_test]") {
+   using backend_t = backend<std::nullptr_t, TestType, dynamic_options>;
+   backend_t backend(mem_wasm, nullptr, dynamic_options{3});
+   backend.set_wasm_allocator(&wa);
+   backend.initialize();
+   CHECK(backend.call_with_return(nullptr, "env", "f")->to_i32() == -1);
+   backend.initialize(nullptr, dynamic_options{4});
+   CHECK(backend.call_with_return(nullptr, "env", "f")->to_i32() == 3);
+   backend.initialize(nullptr, dynamic_options{3});
+   CHECK_THROWS_AS(backend.initialize(nullptr, dynamic_options{2}), std::exception);
+}

--- a/tests/spec/e_memory_tests.cpp
+++ b/tests/spec/e_memory_tests.cpp
@@ -22,7 +22,10 @@ BACKEND_TEST_CASE( "Testing wasm <e_memory_0_wasm>", "[e_memory_0_wasm_tests]" )
 BACKEND_TEST_CASE( "Testing wasm <e_memory_1_wasm>", "[e_memory_1_wasm_tests]" ) {
    using backend_t = backend<std::nullptr_t, TestType>;
    auto code = backend_t::read_wasm( std::string(wasm_directory) + "e_memory.1.wasm");
-   CHECK_THROWS_AS(backend_t(code), std::exception);
+   backend_t bkend( code );
+   bkend.set_wasm_allocator( &wa );
+   bkend.initialize(nullptr);
+
 }
 
 BACKEND_TEST_CASE( "Testing wasm <e_memory_2_wasm>", "[e_memory_2_wasm_tests]" ) {

--- a/tests/spec/extra/memory.wast
+++ b/tests/spec/extra/memory.wast
@@ -7,10 +7,7 @@
 )
 
 ;; This is the maximum allowed under the wasm spec.
-(assert_invalid
-   (module (memory 65536))
-   "Initial memory exceeds implementation defined limits"
-)
+(module (memory 65536))
 
 (module binary
   "\00asm" "\01\00\00\00"

--- a/tests/spec/memory_grow_tests.cpp
+++ b/tests/spec/memory_grow_tests.cpp
@@ -53,10 +53,10 @@ BACKEND_TEST_CASE( "Testing wasm <memory_grow_1_wasm>", "[memory_grow_1_wasm_tes
    CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(1))->to_ui32() == UINT32_C(0));
    CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(0))->to_ui32() == UINT32_C(1));
    CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(2))->to_ui32() == UINT32_C(1));
-   //CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(800))->to_ui32() == UINT32_C(3));
+   CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(800))->to_ui32() == UINT32_C(3));
    CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(65536))->to_ui32() == UINT32_C(4294967295));
    CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(64736))->to_ui32() == UINT32_C(4294967295));
-   //CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(1))->to_ui32() == UINT32_C(803));
+   CHECK(bkend.call_with_return(nullptr, "env", "grow", UINT32_C(1))->to_ui32() == UINT32_C(803));
 }
 
 BACKEND_TEST_CASE( "Testing wasm <memory_grow_2_wasm>", "[memory_grow_2_wasm_tests]" ) {


### PR DESCRIPTION
…ax_call_depth.

Also adjust a few test cases that were adjusted for non-strictly conforming behavior.

This should finish off the eos-vm changes needed for big-code.
