### PR TITLE
[Develop] Switching to using the EOSIO fork of anka-buildkite-plugin for security reasons

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -51,8 +51,9 @@ steps:
       - "cd eos-vm && ./.cicd/build.sh"
       - "cd eos-vm && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     plugins:
-      - chef/anka#v0.5.1:
+      - EOSIO/anka#v0.5.7:
           no-volume: true
+          pre-execute-ping-sleep: "8.8.8.8"
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_40G
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
@@ -116,8 +117,9 @@ steps:
       - "cd eos-vm && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
       - "cd eos-vm && ./.cicd/tests.sh"
     plugins:
-      - chef/anka#v0.5.1:
+      - EOSIO/anka#v0.5.7:
           no-volume: true
+          pre-execute-ping-sleep: "8.8.8.8"
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_40G
           vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"


### PR DESCRIPTION
Problem: We used the chef repo's releases in our CI and this is a potential avenue for attack.

Solution: Fork and use the EOSIO/anka-buildkite-plugin repo.