### PR TITLE
[eosio] Community PR tweaks.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,19 +2,10 @@ name: Pull Request
 on: [pull_request]
 
 jobs:
-  start-job:
-    name: Start Job
-    runs-on: ubuntu-latest
-    steps:
-      - name: Start Job.
-        run: echo "PR created. Builds will be triggered here for forked PRs or Buildkite for internal PRs."
-
-
   amazon_linux-2-build:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Amazon_Linux 2 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -56,7 +47,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: CentOS 7.7 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -98,7 +88,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id  
     name: Ubuntu 16.04 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -140,7 +129,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Ubuntu 18.04 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -182,7 +170,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: MacOS 10.15 | Build
     runs-on: macos-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e


### PR DESCRIPTION
This is a quick change to Actions runs when community PRs are submitted:
- Remove now unnecessary job that executed before build/test steps occurred in Github Actions.
  - This step was required due to a bug in Actions where if all workflow steps were skipped, such as when org based PRs are executed, the build would be marked as failed.
  - The behavior now shows status as expected, where the steps based in the org do now show up at all.

See:
[Actions ](https://github.com/EOSIO/eos-vm/actions/runs/44360310) | Actions run from #158 showing the same functionality as before.
[Actions](https://github.com/EOSIO/eos-vm/actions/runs/44545511) | Actions run created from this PR where all steps are skipped as expected. No checks from Actions show as failed in this PR.