### PR TITLE
Fix Debug build of the tester

### DIFF
--- a/include/eosio/vm/signals.hpp
+++ b/include/eosio/vm/signals.hpp
@@ -12,8 +12,8 @@
 
 namespace eosio { namespace vm {
 
-   inline thread_local std::atomic<sigjmp_buf*> signal_dest = ATOMIC_VAR_INIT(nullptr);
-   inline thread_local std::exception_ptr saved_exception{nullptr};
+   inline thread_local static std::atomic<sigjmp_buf*> signal_dest = ATOMIC_VAR_INIT(nullptr);
+   inline thread_local static std::exception_ptr saved_exception{nullptr};
    template<int Sig>
    inline struct sigaction prev_signal_handler;
 


### PR DESCRIPTION
When trying to do a Debug build of the tester, there's a duplicate symbol error for `signal_dest` and `saved_exception`. Making this change in the history-tools eos-vm submodule and the eos eos-vm submodule resolves the build failure.