### PR TITLE
Test Beta Buildfleets in eos-vm Pipeline

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     env:
       IMAGE_TAG: "amazonlinux-2"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2$SKIP_LINUX
 
@@ -15,7 +15,7 @@ steps:
     env:
       IMAGE_TAG: "centos-7.7"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_CENTOS_7$SKIP_LINUX
 
@@ -24,7 +24,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-16.04"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_16$SKIP_LINUX
 
@@ -33,7 +33,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-18.04"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $BUILD_TIMEOUT
     skip: $SKIP_UBUNTU_18$SKIP_LINUX
 
@@ -84,7 +84,7 @@ steps:
     env:
       IMAGE_TAG: "amazonlinux-2"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $TEST_TIMEOUT
     skip: $SKIP_AMAZON_LINUX_2$SKIP_LINUX
 
@@ -93,7 +93,7 @@ steps:
     env:
       IMAGE_TAG: "centos-7.7"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $TEST_TIMEOUT
     skip: $SKIP_CENTOS_7$SKIP_LINUX
 
@@ -102,7 +102,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-16.04"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $TEST_TIMEOUT
     skip: $SKIP_UBUNTU_16$SKIP_LINUX
 
@@ -111,7 +111,7 @@ steps:
     env:
       IMAGE_TAG: "ubuntu-18.04"
     agents: 
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: $TEST_TIMEOUT
     skip: $SKIP_UBUNTU_18$SKIP_LINUX
 
@@ -161,6 +161,6 @@ steps:
       echo '+++ :javascript: Running test-metrics.js'
       node --max-old-space-size=32768 test-metrics.js
     agents:
-      queue: "automation-eks-eos-builder-fleet"
+      queue: "automation-eks-eos-builder-beta-fleet"
     timeout: 10
     soft_fail: true


### PR DESCRIPTION
## Change Description
From [AUTO-461](https://blockone.atlassian.net/browse/AUTO-461) and auto-eks-buildfleet [build 993](https://buildkite.com/EOSIO/auto-eks-buildfleet/builds/993), a number of our docker containers are failing to build. Most of them appear to be failing due to `get_pip.py` being deprecated for Python 2 installations of `pip`, but we are finding some other bugs introduced, as well.

This pull request points the CI system at two new beta fleets we created, `automation-eks-eos-builder-beta-fleet` and `automation-eks-eos-tester-beta-fleet`, to test that the CI code still works with the upgrades. **This pull request will _NOT_ be merged.**

### See Also
- auto-eks-buildfleet
  - [Pull Request 177](https://github.com/EOSIO/auto-eks-buildfleet/pull/177) - `buildkite-base`
  - [Pull Request 178](https://github.com/EOSIO/auto-eks-buildfleet/pull/178) - `buildkite-eks-ecr-builder`
  - [Pull Request 180](https://github.com/EOSIO/auto-eks-buildfleet/pull/180) - Fix AWS CLI for pre-command Hook in buildkite-eks-ecr-builder Docker Image
  - [Pull Request 181](https://github.com/EOSIO/auto-eks-buildfleet/pull/181) - Create Python 3 Beta Fleets for the EOSIO Builds and Tests
  - [Pull Request 182](https://github.com/EOSIO/auto-eks-buildfleet/pull/182) - upgrade to python3 and awscli2 for terraform buildfleet
  - [Pull Request 183](https://github.com/EOSIO/auto-eks-buildfleet/pull/183) - Terraform doesn't require awscli.
  - [Pull Request 184](https://github.com/EOSIO/auto-eks-buildfleet/pull/184) - Deploy Buildfleet Upgrades to Production
- eos
  - [Pull Request 10002](https://github.com/EOSIO/eos/pull/10002) - `eos:develop`
  - [Pull Request 10003](https://github.com/EOSIO/eos/pull/10003) - `eos:release/2.1.x`
  - [Pull Request 10004](https://github.com/EOSIO/eos/pull/10004) - `eos:release/2.0.x`
  - [Pull Request 10005](https://github.com/EOSIO/eos/pull/10005) - `eos:release/1.8.x`
- eosio.cdt
  - [Pull Request 1049](https://github.com/EOSIO/eosio.cdt/pull/1049) - `eosio.cdt:develop`
  - [Pull Request 1050](https://github.com/EOSIO/eosio.cdt/pull/1050) - `eosio.cdt:release/1.8.x`
  - [Pull Request 1051](https://github.com/EOSIO/eosio.cdt/pull/1051) - `eosio.cdt:release/1.7.x`
- eosio.contracts
  - [Pull Request 555](https://github.com/EOSIO/eosio.contracts/pull/555) - `eosio.contracts:develop`
  - [Pull Request 556](https://github.com/EOSIO/eosio.contracts/pull/556) - `eosio.contracts:release/1.9.x`
  - [Pull Request 557](https://github.com/EOSIO/eosio.contracts/pull/557) - `eosio.contracts:release/1.8.x`
- eos-vm
  - [Pull Request 200](https://github.com/EOSIO/eos-vm/pull/200) - `eos-vm:develop`
  - [Pull Request 201](https://github.com/EOSIO/eos-vm/pull/201) - `eos-vm:eosio`
  - [Pull Request 202](https://github.com/EOSIO/eos-vm/pull/202) - `eos-vm:eosio-2.0.x`
