### PR TITLE
[develop] Update brew steps

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -39,6 +39,7 @@ steps:
 
   - label: ":darwin: macOS 10.14 - Build"
     command:
+      - "brew update && brew upgrade"
       - "brew install git cmake"
       - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos-vm && ./.cicd/build.sh"
@@ -59,6 +60,7 @@ steps:
 
   - label: ":darwin: macOS 10.15 - Build"
     command:
+      - "brew update && brew upgrade"
       - "brew install git cmake"
       - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos-vm && ./.cicd/build.sh"
@@ -117,6 +119,7 @@ steps:
 
   - label: ":darwin: macOS 10.14 - Test"
     command:
+      - "brew update && brew upgrade"
       - "brew install git cmake"
       - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos-vm && ./.cicd/test.sh ':darwin: macOS 10.14 - Build'"
@@ -135,6 +138,7 @@ steps:
 
   - label: ":darwin: macOS 10.15 - Test"
     command:
+      - "brew update && brew upgrade"
       - "brew install git cmake"
       - "git clone $BUILDKITE_REPO eos-vm && cd eos-vm && git checkout $BUILDKITE_COMMIT && git submodule update --init --recursive"
       - "cd eos-vm && ./.cicd/test.sh ':darwin: macOS 10.15 - Build'"


### PR DESCRIPTION
Changes to Homebrew's package management have broken Mac builds where we have Homebrew pre-installed. We'll need to run `brew update`, then `brew upgrade` to update Homebrew properly before trying to install or update any packages in the build process.