### PR TITLE
replace is_callable_v workaround with is_invocable_v; fixes build on clang12

### DIFF
--- a/include/eosio/vm/function_traits.hpp
+++ b/include/eosio/vm/function_traits.hpp
@@ -72,12 +72,6 @@ namespace eosio { namespace vm {
       inline constexpr U&& make_dependent(U&& u) { return static_cast<U&&>(u); }
    }
 
-   template <auto FN>
-   inline constexpr static bool is_callable_v = EOS_VM_HAS_MEMBER(AUTO_PARAM_WORKAROUND(FN), operator());
-
-   template <typename F>
-   constexpr bool is_callable(F&& fn) { return EOS_VM_HAS_MEMBER(fn, operator()); }
-
    namespace detail {
       template <bool Decay, typename R, typename... Args>
       constexpr auto get_types(R(Args...)) -> std::tuple<R, freestanding,
@@ -102,7 +96,7 @@ namespace eosio { namespace vm {
                                                                std::tuple<std::conditional_t<Decay, std::decay_t<Args>, Args>...>>;
       template <bool Decay, typename F>
       constexpr auto get_types(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (std::is_invocable_v<decltype(fn)>)
             return get_types<Decay>(&F::operator());
          else
             return get_types<Decay>(fn);
@@ -144,7 +138,7 @@ namespace eosio { namespace vm {
       constexpr auto parameters_from_impl(R(Cls::*)(Args...)const &&) ->  pack_from_t<N, Args...>;
       template <std::size_t N, typename F>
       constexpr auto parameters_from_impl(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (std::is_invocable_v<decltype(fn)>)
             return parameters_from_impl<N>(&F::operator());
          else
             return parameters_from_impl<N>(fn);


### PR DESCRIPTION
This removes the `is_callable_v` workaround and replaces it with `std::is_invocable_v` as the workaround is causing a
```
template argument for non-type template parameter must be an expression
```
error on clang12. Fixes clang12 and also is compiling on gcc8, clang6, and XCode 10.2 -- pretty much the bare minimum for eosio. But, I'm not sure if it's desirable for eos-vm to support a wider range of compilers and the workaround should be fixed instead. Or if I've just completely missed the purpose of this code in the first place... so please review carefully.