### PR TITLE
Fix compilation error with clang13

### DIFF
--- a/.cicd/pipeline-upload.sh
+++ b/.cicd/pipeline-upload.sh
@@ -12,6 +12,7 @@ fi # the TIMEOUT=${TIMEOUT:-45} syntax does not work in the pipeline.yml for tim
 
 export MACOS_10_14_TAG="eos-vm-macos-10.14-$(sha1sum ./.cicd/platforms/macos-10.14.sh | awk '{print $1}')"
 export MACOS_10_15_TAG="eos-vm-macos-10.15-$(sha1sum ./.cicd/platforms/macos-10.15.sh | awk '{print $1}')"
+export SKIP_MACOS_10_14=true
 
 echo '+++ :pipeline_upload: Deploying Pipeline Steps'
 buildkite-agent pipeline upload .cicd/pipeline.yml

--- a/include/eosio/vm/function_traits.hpp
+++ b/include/eosio/vm/function_traits.hpp
@@ -102,7 +102,7 @@ namespace eosio { namespace vm {
                                                                std::tuple<std::conditional_t<Decay, std::decay_t<Args>, Args>...>>;
       template <bool Decay, typename F>
       constexpr auto get_types(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (is_callable<decltype(fn)>())
             return get_types<Decay>(&F::operator());
          else
             return get_types<Decay>(fn);
@@ -144,7 +144,7 @@ namespace eosio { namespace vm {
       constexpr auto parameters_from_impl(R(Cls::*)(Args...)const &&) ->  pack_from_t<N, Args...>;
       template <std::size_t N, typename F>
       constexpr auto parameters_from_impl(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (is_callable<decltype(fn)>())
             return parameters_from_impl<N>(&F::operator());
          else
             return parameters_from_impl<N>(fn);


### PR DESCRIPTION
When using clang13 built from source, like in a pinned build, eos-vm code that otherwise compiles fine will break. This PR makes a small change to fix that compilation error with clang13.