### PR TITLE
target option eosio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(eos-vm
                            INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
                                      ${CMAKE_CURRENT_SOURCE_DIR}/external/softfloat/source/include)
 # ignore the C++17 register warning until clean up
-target_compile_options( eos-vm INTERFACE "-Wno-register" )
+target_compile_options( eos-vm INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> )
 
 # ##################################################################################################
 # Enable debugging stats for eos-vm.

--- a/include/eosio/vm/variant.hpp
+++ b/include/eosio/vm/variant.hpp
@@ -183,10 +183,14 @@ namespace eosio { namespace vm {
       template <typename T,
                 typename = std::enable_if_t<detail::is_valid_alternative_v<std::decay_t<T>, Alternatives...>>>
       constexpr variant& operator=(T&& alt) {
+#if (defined(__GNUC__) && !defined(__clang__))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
          _storage = static_cast<T&&>(alt);
 #pragma GCC diagnostic pop
+#else
+         _storage = static_cast<T&&>(alt);
+#endif
          _which = detail::get_alternatives_index_v<std::decay_t<T>, Alternatives...>;
          return *this;
       }


### PR DESCRIPTION
This PR 
- avoids the warning that `-Wno-regiester` is not a valid option for C compiler,
- avoids the warning that `-Wmaybe-uninitialized` is not recognize option for clang++ compiler. 

PR #224 
