### PR TITLE
Enable eos-vm for non x86-64 platform

### DIFF
--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -9,7 +9,9 @@
 #include <eosio/vm/null_writer.hpp>
 #include <eosio/vm/parser.hpp>
 #include <eosio/vm/types.hpp>
+#ifdef __x86_64__
 #include <eosio/vm/x86_64.hpp>
+#endif 
 
 #include <atomic>
 #include <exception>
@@ -20,6 +22,7 @@
 #include <vector>
 
 namespace eosio { namespace vm {
+#ifdef __x86_64__
 
    struct jit {
       template<typename Host>
@@ -36,7 +39,7 @@ namespace eosio { namespace vm {
       using parser = binary_parser<machine_code_writer<context<Host>>, Options, DebugInfo>;
       static constexpr bool is_jit = true;
    };
-
+#endif
    struct interpreter {
       template<typename Host>
       using context = execution_context<Host>;

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -208,6 +208,7 @@ namespace eosio { namespace vm {
       void* volatile _top_frame = nullptr;
    };
 
+#ifdef __x86_64__
    template<typename Host, bool EnableBacktrace = false>
    class jit_execution_context : public frame_info_holder<EnableBacktrace>, public execution_context_base<jit_execution_context<Host, EnableBacktrace>, Host> {
       using base_type = execution_context_base<jit_execution_context<Host, EnableBacktrace>, Host>;
@@ -472,6 +473,7 @@ namespace eosio { namespace vm {
       host_type * _host = nullptr;
       uint32_t _remaining_call_depth;
    };
+#endif
 
    template <typename Host>
    class execution_context : public execution_context_base<execution_context<Host>, Host> {


### PR DESCRIPTION
This PR allows eos-vm to work on non x86-64 platform